### PR TITLE
Add BinaryResponseWriter, so that PDFs can be sent through the API

### DIFF
--- a/src/main/java/com/zandero/rest/writer/BinaryResponseWriter.java
+++ b/src/main/java/com/zandero/rest/writer/BinaryResponseWriter.java
@@ -1,0 +1,26 @@
+package com.zandero.rest.writer;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.http.HttpServerResponse;
+
+/**
+ * Writes binary data to response, takes byte[] as input
+ * Example Usecase: Downloading PDF
+ *
+ */
+public class BinaryResponseWriter<T> implements HttpResponseWriter<T> {
+    @Override
+    public void write(T result, HttpServerRequest request, HttpServerResponse response) throws Throwable {
+        if (result == null) {
+            response.setStatusCode(204).end(); // No Content
+            return;
+        }
+
+        if (result instanceof byte[]) {
+            response.end(Buffer.buffer((byte[]) result));
+        } else {
+            response.setStatusCode(500).end("Unsupported file type");
+        }
+    }
+}


### PR DESCRIPTION
I have a usecase where I need to attatch a PDF (byte[]) to the response, so that the client can download said PDF. Added this writer to my project.
Thought it might be helpful if it were included in the base project.